### PR TITLE
Revbayes banner message not printed on Linux

### DIFF
--- a/R/CallRev.R
+++ b/R/CallRev.R
@@ -116,6 +116,7 @@ callRev <- function (..., coerce = FALSE, path = Sys.getenv("rb"), viewCode = FA
     drop_idx <- c(seq_len(13), length(out) - 1, length(out))
     drop_idx <- drop_idx[drop_idx > 0 & drop_idx <= length(out)]
     out <- out[-drop_idx]
+    }
   
   cat("Input:\n -->  " %+% ret %+% "\n//", file = tf,
       sep = "\n", append = FALSE)


### PR DESCRIPTION
I found that Revticulate did not work on my desktop Linux system. After a bit of digging, I found out that the function `callRev()` expects there to be 13 lines of banner code after executing a temp file. On my system (Fedora) this is not the case, leading to an error message, rendering the entire package non-functional.
I implemented a quick and dirty check for this banner, to only remove these lines if present. Note: I have not tested it on MacOS or Windows. Could you please look into this?

Also, there was an issue with retrieving the file path of the temporary rev file, which I fixed (again, only tested on my system).

Best,
Mario