### PR TITLE
Fix zero characters

### DIFF
--- a/R/CallRev.R
+++ b/R/CallRev.R
@@ -108,7 +108,7 @@ callRev <- function (..., coerce = FALSE, path = Sys.getenv("rb"), viewCode = FA
   fopen <- file(tf)
   ret <- unlist(argu)
   writeLines(ret, fopen, sep = "\n")
-  out <- system2(path, args = c(tf), stdout = TRUE, timeout=timeout)
+  out <- system2(path, args = c(tf), stdout = "", timeout=timeout)
   
   has_banner <- any(grepl("RevBayes version", out))
   


### PR DESCRIPTION
Sorry for bothering again with my Linux desktop.
While the main Revticulate commands worked after my fix from yesterday (#6 ), I could not execute the RevBayes code blocks because when Revticulate read the shell, it read in `\0` characters. I tried a ton of ways of how to filter them out but it either broke the package build or the `\0` characters were not removed. Then, I stumbled over [this post](https://stackoverflow.com/questions/61067574/embedded-nul-warnings-when-invoking-system2-with-stdout-true-on-windows). Simply replacing `stdout = TRUE` to `stdout = ""` did the trick for me. But, I don't know whether this would break the package on Windows or MacOS.
Sorry for the messy pull request, I had to buid upon my branch from yesterday.