### PR TITLE
Revert "Fix zero characters"

### DIFF
--- a/R/CallRev.R
+++ b/R/CallRev.R
@@ -100,24 +100,16 @@ callRev <- function (..., coerce = FALSE, path = Sys.getenv("rb"), viewCode = FA
     argu <- c("setwd(\"" %+% wd %+% "\")", argu)
   }
 
-  tf <- tempfile(pattern = "file", tmpdir = file.path(Sys.getenv("revTemps")), fileext = ".rev")
-
+  tf <- tempfile(pattern = "file", tmpdir = paste(Sys.getenv("revTemps"),
+                                                  "/", sep = ""), fileext = ".rev")
 
   tf <- suppressWarnings((gsub(pattern = "\\\\", "/", tf)))
 
   fopen <- file(tf)
   ret <- unlist(argu)
   writeLines(ret, fopen, sep = "\n")
-  out <- system2(path, args = c(tf), stdout = "", timeout=timeout)
-  
-  has_banner <- any(grepl("RevBayes version", out))
-  
-  if (has_banner) {
-    drop_idx <- c(seq_len(13), length(out) - 1, length(out))
-    drop_idx <- drop_idx[drop_idx > 0 & drop_idx <= length(out)]
-    out <- out[-drop_idx]
-    }
-  
+  out <- system2(path, args = c(tf), stdout = TRUE, timeout=timeout)
+  out <- out[-c(1:13, length(out) - 1, length(out))]
   cat("Input:\n -->  " %+% ret %+% "\n//", file = tf,
       sep = "\n", append = FALSE)
   cat("Output:\n -->  " %+% out %+% "\n//", file = tf,


### PR DESCRIPTION
Clearly I got ahead of myself when merging #7, and didn't test it thoroughly enough. Using `stdout = ""` instead of `stdout = TRUE` in `doRev()` makes it impossible to capture the output of the function in an R variable, so this is not going to work. I wonder if the difficulties @mcranium was having on Linux might be better circumvented by using `system()` rather than `system2()`...